### PR TITLE
Make Shwift compatible with Swift 5.9

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -7,8 +7,8 @@ on:
   pull_request: {}
 
 env:
-  swift-branch: swift-5.8-release
-  swift-tag: 5.8-RELEASE
+  swift-branch: swift-5.8.1-release
+  swift-tag: 5.8.1-RELEASE
 
 jobs:
 

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -36,9 +36,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04, macos-13
             swift:
-              version: "5.7"
+              version: "5.8"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -6,17 +6,22 @@ on:
       - main
   pull_request: {}
 
+env:
+  swift-branch: swift-5.8-release
+  swift-tag: 5.8-RELEASE
+
 jobs:
 
   validate-formatting:
     name: Validate Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Correct Swift Version
-        uses: slashmo/install-swift@v0.1.0
+        uses: georgelyon/gha-setup-swift@main
         with:
-          version: "5.8"
+          branch: ${{ env.swift-branch }}
+          tag:  ${{ env.swift-tag }}
       - name: Build Formatting Tools
         run: |
           swift build --product swift-format
@@ -35,17 +40,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-20.04, macos-13
-            swift:
-              version: "5.8"
+        os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Correct Swift Version
-        uses: slashmo/install-swift@v0.1.0
+        uses: georgelyon/gha-setup-swift@main
         with:
-          version: ${{ matrix.swift.version }}
+          branch: ${{ env.swift-branch }}
+          tag:  ${{ env.swift-tag }}
       - run: swift build
       - run: swift test
       - run: swift run ScriptExample

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Correct Swift Version
-        uses: compnerd/gha-setup-swift@main
+        uses: georgelyon/gha-setup-swift@main
         with:
           branch: ${{ env.swift-branch }}
           tag:  ${{ env.swift-tag }}
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Correct Swift Version
-        uses: compnerd/gha-setup-swift@main
+        uses: georgelyon/gha-setup-swift@main
         with:
           branch: ${{ env.swift-branch }}
           tag:  ${{ env.swift-tag }}

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Correct Swift Version
-        uses: georgelyon/gha-setup-swift@main
+        uses: compnerd/gha-setup-swift@main
         with:
           branch: ${{ env.swift-branch }}
           tag:  ${{ env.swift-tag }}
@@ -36,7 +36,7 @@ jobs:
           git diff-index --quiet HEAD --
 
   test:
-    name: Test on Linux
+    name: Run Tests
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Correct Swift Version
-        uses: georgelyon/gha-setup-swift@main
+        uses: compnerd/gha-setup-swift@main
         with:
           branch: ${{ env.swift-branch }}
           tag:  ${{ env.swift-tag }}

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -26,11 +26,9 @@ jobs:
         run: |
           swift build --product swift-format
       - name: Validate swift formatting
-        # We ignore unparseable files because, for some reason, Process.swift breaks swift-format
         run: |
           swift run swift-format \
             --in-place \
-            --ignore-unparsable-files \
             --recursive Sources Tests
           git diff
           git diff-index --quiet HEAD --

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Correct Swift Version
         uses: slashmo/install-swift@v0.1.0
         with:
-          version: "5.7"
+          version: "5.8"
       - name: Build Formatting Tools
         run: |
           swift build --product swift-format

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
           "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
@@ -14,8 +14,8 @@
         "package": "swift-format",
         "repositoryURL": "https://github.com/apple/swift-format",
         "state": {
-          "branch": "release/5.7",
-          "revision": "3dd9b517b9e9846435aa782d769ef5825e7c2d65",
+          "branch": "release/5.8",
+          "revision": "fbfe1869527923dd9f9b2edac148baccfce0dce7",
           "version": null
         }
       },
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "04d4497be6b88e524a71778d828790e9589ae1c4",
-          "version": "0.50700.0"
+          "revision": "2c49d66d34dfd6f8130afdba889de77504b58ec0",
+          "version": "508.0.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "4f07be3dc201f6e2ee85b6942d0c220a16926811",
-          "version": "0.2.7"
+          "revision": "93784c59434dbca8e8a9e4b700d0d6d94551da6a",
+          "version": "0.5.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .library(name: "Shwift", targets: ["Shwift"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-format", .branch("release/5.7")),
+    .package(url: "https://github.com/apple/swift-format", .branch("release/5.8")),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-system", from: "1.1.1"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),

--- a/Sources/Shwift/Process.swift
+++ b/Sources/Shwift/Process.swift
@@ -76,19 +76,19 @@ public struct Process {
       }
     }
     return Task {
-      try await withTaskCancellationHandler(
-        handler: { process.terminate() }, 
-        operation: {
-          try await monitor.wait()
-          logger?.willWait(on: process)
-          do {
-            try await process.wait(in: context)
-            logger?.process(process, didTerminateWithError: nil)
-          } catch {
-            logger?.process(process, didTerminateWithError: error)
-            throw error
-          }
-        })
+      try await withTaskCancellationHandler {
+        try await monitor.wait()
+        logger?.willWait(on: process)
+        do {
+          try await process.wait(in: context)
+          logger?.process(process, didTerminateWithError: nil)
+        } catch {
+          logger?.process(process, didTerminateWithError: error)
+          throw error
+        }
+      } onCancel: {
+        process.terminate()
+      }
     }
   }
 

--- a/Sources/Shwift/Process.swift
+++ b/Sources/Shwift/Process.swift
@@ -1,10 +1,10 @@
 #if canImport(Darwin)
-import Darwin
+  import Darwin
 #elseif canImport(Glibc)
-import Glibc
-import CLinuxSupport
+  import Glibc
+  import CLinuxSupport
 #else
-#error("Unsupported Platform")
+  #error("Unsupported Platform")
 #endif
 
 @_implementationOnly import NIO
@@ -28,14 +28,15 @@ public struct Process {
     in context: Context
   ) async throws {
     try await launch(
-      executablePath: executablePath, 
-      arguments: arguments, 
-      environment: environment, 
-      workingDirectory: workingDirectory, 
-      fileDescriptors: fileDescriptors, 
-      logger: logger, 
-      in: context)
-      .value
+      executablePath: executablePath,
+      arguments: arguments,
+      environment: environment,
+      workingDirectory: workingDirectory,
+      fileDescriptors: fileDescriptors,
+      logger: logger,
+      in: context
+    )
+    .value
   }
 
   /**
@@ -53,7 +54,8 @@ public struct Process {
   ) async throws -> Task<Void, Error> {
     let process: Process
     let monitor: FileDescriptorMonitor
-    (process, monitor) = try await FileDescriptorMonitor.create(in: context) { monitoredDescriptor in
+    (process, monitor) = try await FileDescriptorMonitor.create(in: context) {
+      monitoredDescriptor in
       do {
         var fileDescriptors = fileDescriptors
         /// Map the monitored descriptor to the lowest unmapped target descriptor
@@ -101,77 +103,79 @@ public struct Process {
     context: Context
   ) async throws {
     #if canImport(Darwin)
-    var attributes = try PosixSpawn.Attributes()
-    defer { try! attributes.destroy() }
-    try attributes.setFlags([
-      .closeFileDescriptorsByDefault,
-      .setSignalMask,
-    ])
-    try attributes.setBlockedSignals(to: .none)
-    
-    var actions = try PosixSpawn.FileActions()
-    defer { try! actions.destroy() }
-    try actions.addChangeDirectory(to: workingDirectory)
-    for entry in fileDescriptors.entries {
-      try actions.addDuplicate(entry.source, as: entry.target)
-    }
-  
-    id = ID(
-      rawValue: try PosixSpawn.spawn(
-        executablePath,
-        arguments: [executablePath.string] + arguments,
-        environment: environment.strings,
-        fileActions: &actions,
-        attributes: &attributes))!
-    #elseif canImport(Glibc)
-    let invocation: OpaquePointer = executablePath.withPlatformString { executablePath in
-      workingDirectory.withPlatformString { workingDirectory in
-        ShwiftSpawnInvocationCreate(
-          executablePath,
-          workingDirectory,
-          Int32(arguments.count + 1),
-          Int32(environment.strings.count),
-          Int32(fileDescriptors.entries.count))!
-      }
-    }
+      var attributes = try PosixSpawn.Attributes()
+      defer { try! attributes.destroy() }
+      try attributes.setFlags([
+        .closeFileDescriptorsByDefault,
+        .setSignalMask,
+      ])
+      try attributes.setBlockedSignals(to: .none)
 
-    /// Use a closure to make sure no errors are thrown before we can complete the invocation
-    id = await {
+      var actions = try PosixSpawn.FileActions()
+      defer { try! actions.destroy() }
+      try actions.addChangeDirectory(to: workingDirectory)
       for entry in fileDescriptors.entries {
-        ShwiftSpawnInvocationAddFileDescriptorMapping(invocation, entry.source.rawValue, entry.target)
+        try actions.addDuplicate(entry.source, as: entry.target)
       }
 
-      executablePath.withPlatformString { path in
-        ShwiftSpawnInvocationAddArgument(invocation, path)
-      }
-      for argument in arguments {
-        argument.withCString { argument in
-          ShwiftSpawnInvocationAddArgument(invocation, argument)
-        }
-      }
-      
-      for entry in environment.strings {
-        entry.withCString { entry in
-          ShwiftSpawnInvocationAddEnvironmentEntry(invocation, entry)
+      id = ID(
+        rawValue: try PosixSpawn.spawn(
+          executablePath,
+          arguments: [executablePath.string] + arguments,
+          environment: environment.strings,
+          fileActions: &actions,
+          attributes: &attributes))!
+    #elseif canImport(Glibc)
+      let invocation: OpaquePointer = executablePath.withPlatformString { executablePath in
+        workingDirectory.withPlatformString { workingDirectory in
+          ShwiftSpawnInvocationCreate(
+            executablePath,
+            workingDirectory,
+            Int32(arguments.count + 1),
+            Int32(environment.strings.count),
+            Int32(fileDescriptors.entries.count))!
         }
       }
 
-      let id: Process.ID
-      let monitor: FileDescriptorMonitor
-      (id, monitor) = try! await FileDescriptorMonitor.create(in: context) { monitoredDescriptor in
-        ID(rawValue: ShwiftSpawnInvocationLaunch(invocation, monitoredDescriptor.rawValue))!
+      /// Use a closure to make sure no errors are thrown before we can complete the invocation
+      id = await {
+        for entry in fileDescriptors.entries {
+          ShwiftSpawnInvocationAddFileDescriptorMapping(
+            invocation, entry.source.rawValue, entry.target)
+        }
+
+        executablePath.withPlatformString { path in
+          ShwiftSpawnInvocationAddArgument(invocation, path)
+        }
+        for argument in arguments {
+          argument.withCString { argument in
+            ShwiftSpawnInvocationAddArgument(invocation, argument)
+          }
+        }
+
+        for entry in environment.strings {
+          entry.withCString { entry in
+            ShwiftSpawnInvocationAddEnvironmentEntry(invocation, entry)
+          }
+        }
+
+        let id: Process.ID
+        let monitor: FileDescriptorMonitor
+        (id, monitor) = try! await FileDescriptorMonitor.create(in: context) {
+          monitoredDescriptor in
+          ID(rawValue: ShwiftSpawnInvocationLaunch(invocation, monitoredDescriptor.rawValue))!
+        }
+        try! await monitor.wait()
+        return id
+      }()
+      var failure = ShwiftSpawnInvocationFailure()
+      guard ShwiftSpawnInvocationComplete(invocation, &failure) else {
+        throw SpawnError(
+          file: String(cString: failure.file),
+          line: failure.line,
+          returnValue: failure.returnValue,
+          errorNumber: failure.errorNumber)
       }
-      try! await monitor.wait()
-      return id
-    }()
-    var failure = ShwiftSpawnInvocationFailure();
-    guard ShwiftSpawnInvocationComplete(invocation, &failure) else {
-      throw SpawnError(
-        file: String(cString: failure.file),
-        line: failure.line,
-        returnValue: failure.returnValue,
-        errorNumber: failure.errorNumber)
-    }
     #endif
   }
 
@@ -186,15 +190,15 @@ public struct Process {
   private func wait(in context: Context) async throws {
     /// Some key paths are different on Linux and macOS
     #if canImport(Darwin)
-    let pid = \siginfo_t.si_pid
-    let sigchldInfo = \siginfo_t.self
-    let killingSignal = \siginfo_t.si_status
+      let pid = \siginfo_t.si_pid
+      let sigchldInfo = \siginfo_t.self
+      let killingSignal = \siginfo_t.si_status
     #elseif canImport(Glibc)
-    let pid = \siginfo_t._sifields._sigchld.si_pid
-    let sigchldInfo = \siginfo_t._sifields._sigchld
-    let killingSignal = \siginfo_t._sifields._rt.si_sigval.sival_int
+      let pid = \siginfo_t._sifields._sigchld.si_pid
+      let sigchldInfo = \siginfo_t._sifields._sigchld
+      let killingSignal = \siginfo_t._sifields._rt.si_sigval.sival_int
     #endif
-    
+
     var info = siginfo_t()
     while true {
       /**
@@ -206,7 +210,7 @@ public struct Process {
         errno = 0
         var flags = WEXITED | WNOHANG
         #if canImport(Glibc)
-        flags |= __WALL
+          flags |= __WALL
         #endif
         let returnValue = waitid(P_PID, id_t(id.rawValue), &info, flags)
         guard returnValue == 0 else {
@@ -220,7 +224,7 @@ public struct Process {
         /// Reset `info`
         info = siginfo_t()
         /// Wait for 1 second (we can't use `Task.sleep` because we want to wait on the child process even if it was cancelled)
-        let _ : Void = await withCheckedContinuation { continuation in
+        let _: Void = await withCheckedContinuation { continuation in
           context.eventLoopGroup.next().scheduleTask(in: .seconds(1)) {
             continuation.resume()
           }
@@ -278,30 +282,31 @@ public protocol ProcessLogger {
 // MARK: - File Descriptor Mapping
 
 public extension Process {
-  
+
   struct FileDescriptorMapping: ExpressibleByDictionaryLiteral {
-    
+
     public init() {
       self.init(entries: [])
     }
-    
+
     public init(
       standardInput: SystemPackage.FileDescriptor,
       standardOutput: SystemPackage.FileDescriptor,
       standardError: SystemPackage.FileDescriptor,
       additionalFileDescriptors: KeyValuePairs<CInt, SystemPackage.FileDescriptor> = [:]
     ) {
-      self.init(entries: [
-        (source: standardInput, target: STDIN_FILENO),
-        (source: standardOutput, target: STDOUT_FILENO),
-        (source: standardError, target: STDERR_FILENO),
-      ] + additionalFileDescriptors.map { (source: $0.value, target: $0.key) })
+      self.init(
+        entries: [
+          (source: standardInput, target: STDIN_FILENO),
+          (source: standardOutput, target: STDOUT_FILENO),
+          (source: standardError, target: STDERR_FILENO),
+        ] + additionalFileDescriptors.map { (source: $0.value, target: $0.key) })
     }
-    
+
     public init(dictionaryLiteral elements: (CInt, SystemPackage.FileDescriptor)...) {
       self.init(entries: elements.map { (source: $0.1, target: $0.0) })
     }
-    
+
     public mutating func addMapping(
       from source: SystemPackage.FileDescriptor,
       to target: CInt
@@ -309,7 +314,7 @@ public extension Process {
       precondition(!entries.contains(where: { $0.target == target }))
       entries.append((source: source, target: target))
     }
-    
+
     private init(entries: [Entry]) {
       /// Ensure each file descriptor is only mapped to once
       precondition(Set(entries.map(\.target)).count == entries.count)
@@ -318,7 +323,7 @@ public extension Process {
     fileprivate typealias Entry = (source: SystemPackage.FileDescriptor, target: CInt)
     fileprivate private(set) var entries: [Entry]
   }
-  
+
 }
 
 // MARK: - Errors
@@ -359,7 +364,7 @@ extension Process {
 private struct FileDescriptorMonitor {
 
   static func create<T>(
-    in context: Context, 
+    in context: Context,
     _ forwardMonitoredDescriptor: (SystemPackage.FileDescriptor) async throws -> T
   ) async throws -> (outcome: T, monitor: FileDescriptorMonitor) {
     let future: EventLoopFuture<Void>

--- a/Support/Docker/Dockerfile
+++ b/Support/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.6-focal
+FROM swift:5.8-jammy
 # FROM swiftlang/swift:nightly-main-focal
 
 RUN apt-get update

--- a/Support/Docker/devcontainer.json
+++ b/Support/Docker/devcontainer.json
@@ -6,13 +6,16 @@
     "--security-opt",
     "seccomp=unconfined"
   ],
-  "settings": {
-    "lldb.adapterType": "bundled",
-    "lldb.executable": "/usr/bin/lldb",
-    "terminal.integrated.defaultProfile.linux": "/bin/bash",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "lldb.adapterType": "bundled",
+        "lldb.executable": "/usr/bin/lldb",
+        "terminal.integrated.defaultProfile.linux": "/bin/bash",
+      },
+      "extensions": [
+        "sswg.swift-lang"
+      ],
+    }
   },
-  "extensions": [
-    "pvasek.sourcekit-lsp--dev-unofficial",
-    "vadimcn.vscode-lldb",
-  ],
 }

--- a/Tests/ShwiftTests/Shwift Tests.swift
+++ b/Tests/ShwiftTests/Shwift Tests.swift
@@ -42,22 +42,21 @@ final class ShwiftCoreTests: XCTestCase {
       is: .failure)
   }
 
-  func textExecutablePipe() throws {
+  func testExecutablePipe() throws {
     try XCTAssertOutput(
       of: { context, output in
         try await Builtin.pipe(
           { output in
-            try await Process.run("echo", "Input", standardOutput: output, in: context)
+            try await Process.run("echo", "Foo", standardOutput: output, in: context)
           },
           to: { input in
             try await Process.run(
-              "sed", "s/Input/Output/", standardInput: input, standardOutput: output, in: context)
+              "sed", "s/Foo/Bar/", standardInput: input, standardOutput: output, in: context)
           }
         ).destination
       },
       is: """
-        Echo
-        Cat
+        Bar
         """)
   }
 


### PR DESCRIPTION
- only one deprecated method needed to be re-named
- at the same time, bump all testing to Swift 5.8