### PR TITLE
Fix 22 - accumulate remainder in Lines.makeAsyncIterator

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,10 @@ let package = Package(
       ]
     ),
     .testTarget(
+      name: "ScriptTests",
+      dependencies: ["Script"]
+    ),
+    .testTarget(
       name: "ShwiftTests",
       dependencies: ["Shwift"],
       resources: [

--- a/Sources/Script/List Comprehensions.swift
+++ b/Sources/Script/List Comprehensions.swift
@@ -10,15 +10,17 @@ public func map(transform: @Sendable @escaping (String) async throws -> String)
   compactMap(transform: transform)
 }
 
-public func compactMap(transform: @Sendable @escaping (String) async throws -> String?)
-  -> Shell.PipableCommand<Void>
-{
+public func compactMap(
+  segmentingInputAt delimiter: Character = "\n",
+  withOutputTerminator terminator: String = "\n",
+  transform: @Sendable @escaping (String) async throws -> String?
+) -> Shell.PipableCommand<Void> {
   Shell.PipableCommand {
     try await Shell.invoke { shell, invocation in
       try await invocation.builtin { channel in
-        for try await line in channel.input.lines.compactMap(transform) {
+        for try await line in channel.input.segmented(by: delimiter).compactMap(transform) {
           try await channel.output.withTextOutputStream { stream in
-            print(line, to: &stream)
+            print(line, terminator: terminator, to: &stream)
           }
         }
       }

--- a/Sources/Shwift/Builtins.swift
+++ b/Sources/Shwift/Builtins.swift
@@ -105,7 +105,7 @@ extension Builtin {
                   at: buffer.readerIndex,
                   length: buffer.readableBytes)!
                 var substring = readString[readString.startIndex...]
-                while let lineBreak = substring.firstIndex(of: "\n") {
+                while let lineBreak = substring.firstIndex(of: delimiter) {
                   let line = substring[substring.startIndex..<lineBreak]
                   substring = substring[substring.index(after: lineBreak)...]
                   continuation.yield(remainder + String(line))
@@ -126,9 +126,20 @@ extension Builtin {
       }
 
       fileprivate let byteBuffers: ByteBuffers
+      fileprivate let delimiter: Character
     }
+
+    /// Make a Lines iterator splitting at newlines
     public var lines: Lines {
-      Lines(byteBuffers: byteBuffers)
+      segmented()
+    }
+
+    /// Make a Lines iterator yielding text segments between delimiters (like split).
+    ///
+    /// - Parameter delimiter: Character separating input text to yield (and not itself yielded)  Defaults to newline.
+    /// - Returns: Lines segmented by delimiter
+    public func segmented(by delimiter: Character = "\n") -> Lines {
+      Lines(byteBuffers: byteBuffers, delimiter: delimiter)
     }
 
     typealias ByteBuffers = AsyncCompactMapSequence<

--- a/Sources/Shwift/Builtins.swift
+++ b/Sources/Shwift/Builtins.swift
@@ -111,7 +111,7 @@ extension Builtin {
                   continuation.yield(remainder + String(line))
                   remainder = ""
                 }
-                remainder = String(substring)
+                remainder += String(substring)
               }
               if !remainder.isEmpty {
                 continuation.yield(String(remainder))

--- a/Tests/ScriptTests/Script Tests.swift
+++ b/Tests/ScriptTests/Script Tests.swift
@@ -30,6 +30,18 @@ final class ScriptCoreTests: XCTestCase {
     }
   }
 
+  /// Demo [#22 dropped remainder](https://github.com/GeorgeLyon/Shwift/issues/22)
+  func testEchoMapWithDelimiters() async throws {
+    try runInScript {
+      let result = try await outputOf {
+        try await echo("1", "2", separator: ",", terminator: "")
+        | compactMap(segmentingInputAt: ",", withOutputTerminator: "|") { "<\($0)>"}
+      }
+      let exp = "<1>|<2>|"
+      XCTAssertEqual(exp, result, "echo 1,2 -map-> <1>|<2>|")
+    }
+  }
+
   /// Run test in Script.run() context
   private func runInScript(
     _ op: @escaping RunInScriptProxy.Op,

--- a/Tests/ScriptTests/Script Tests.swift
+++ b/Tests/ScriptTests/Script Tests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import Script
+
+final class ScriptCoreTests: XCTestCase {
+
+  func testEcho() async throws {
+    try runInScript {
+      var result: String
+      result = try await outputOf {
+        try await echo("1", "2")
+      }
+      // fyi, trailing newline stripped by outputOf
+      XCTAssertEqual("1 2", result, "echo 1 2")
+
+      result = try await outputOf {
+        try await echo("1", "2", separator: ",", terminator: ";")
+      }
+      XCTAssertEqual("1,2;", result, "echo 1,2;")
+    }
+  }
+
+  func testEchoMap() async throws {
+    try runInScript {
+      var result: String
+      result = try await outputOf {
+        // inject newline so map op runs on head then tail
+        try await echo("1", "2", "\n", "3", "4") | map(){"<\($0)>"}
+      }
+      XCTAssertEqual("<1 2 >\n< 3 4>", result, "echo 1 2 \n 3 4 | map{<$0>}")
+    }
+  }
+
+  /// Run test in Script.run() context
+  private func runInScript(
+    _ op: @escaping RunInScriptProxy.Op,
+    caller: StaticString = #function,
+    callerLine: UInt = #line
+  ) throws {
+    let e = expectation(description: "\(caller):\(callerLine)")
+    try RunInScriptProxy(op, e).run() // sync call preferred
+    wait(for: [e], timeout: 2)
+  }
+
+  private struct RunInScriptProxy: Script {
+    typealias Op = () async throws -> Void
+    var op: Op?
+    var e: XCTestExpectation?
+    init(_ op: @escaping Op, _ e: XCTestExpectation) {
+      self.op = op
+      self.e = e
+    }
+    func run() async throws {
+      defer { e?.fulfill() }
+      try await op?()
+    }
+    // Codable
+    init() {}
+    var i = 0
+    private enum CodingKeys: String, CodingKey {
+      case i
+    }
+  }
+}
+


### PR DESCRIPTION
This is the PR planned in #22.  A fix is the 1-character change (`+=`) in the last commit, to accumulate the remainder when there are missing delimiters.

The first five commits are tests, then enough delimiter implementation to demo the bug, and then the test that fails without the fix.

For testing, I'm not confident that the way I wrapped Script is the best, since it puts validation inside the script.  Also it seems there should be an easier way to drive the bug test.

I imagine there may be API issues with the delimiters and terminators used to drive the test, but I'm assuming we can address those in a PR for #20, which I'll base off these changes.  Since that PR includes these changes, you might find it easier to just go through those commits.

Thanks!