### PR TITLE
Segmented lines, #22 fix, and splitInput for #20

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,10 @@ let package = Package(
       ]
     ),
     .testTarget(
+      name: "ScriptTests",
+      dependencies: ["Script"]
+    ),
+    .testTarget(
       name: "ShwiftTests",
       dependencies: ["Shwift"],
       resources: [

--- a/Sources/Script/Output Capture.swift
+++ b/Sources/Script/Output Capture.swift
@@ -1,4 +1,21 @@
+import Shwift
+
 public func outputOf(_ operation: @escaping () async throws -> Void) async throws -> String {
   let lines = try await Shell.PipableCommand(operation) | reduce(into: []) { $0.append($1) }
   return lines.joined(separator: "\n")
+}
+
+public func splitInput<T>(
+  on separator: Character = "\n",
+  into initialResult: T,
+  _ updateAccumulatingResult: @escaping (inout T, String) async throws -> Void
+) -> Shell.PipableCommand<T> {
+  Shell.PipableCommand {
+    try await Shell.invoke { _, invocation in
+      try await invocation.builtin { channel in
+        try await channel.input.segmented(by: separator)
+          .reduce(into: initialResult, updateAccumulatingResult)
+      }
+    }
+  }
 }

--- a/Sources/Shwift/Builtins.swift
+++ b/Sources/Shwift/Builtins.swift
@@ -105,7 +105,7 @@ extension Builtin {
                   at: buffer.readerIndex,
                   length: buffer.readableBytes)!
                 var substring = readString[readString.startIndex...]
-                while let lineBreak = substring.firstIndex(of: "\n") {
+                while let lineBreak = substring.firstIndex(of: delimiter) {
                   let line = substring[substring.startIndex..<lineBreak]
                   substring = substring[substring.index(after: lineBreak)...]
                   continuation.yield(remainder + String(line))
@@ -126,9 +126,20 @@ extension Builtin {
       }
 
       fileprivate let byteBuffers: ByteBuffers
+      fileprivate let delimiter: Character
     }
+
+    /// Make a Lines iterator splitting at newlines
     public var lines: Lines {
-      Lines(byteBuffers: byteBuffers)
+      segmented()
+    }
+
+    /// Make a Lines iterator yielding text segments between delimiters (like split).
+    ///
+    /// - Parameter delimiter: Character separating input text to yield (and not itself yielded)  Defaults to newline.
+    /// - Returns: Lines segmented by delimiter
+    public func segmented(by delimiter: Character = "\n") -> Lines {
+      Lines(byteBuffers: byteBuffers, delimiter: delimiter)
     }
 
     typealias ByteBuffers = AsyncCompactMapSequence<

--- a/Sources/Shwift/Builtins.swift
+++ b/Sources/Shwift/Builtins.swift
@@ -111,7 +111,7 @@ extension Builtin {
                   continuation.yield(remainder + String(line))
                   remainder = ""
                 }
-                remainder = String(substring)
+                remainder += String(substring)
               }
               if !remainder.isEmpty {
                 continuation.yield(String(remainder))

--- a/Tests/ScriptTests/Script Tests.swift
+++ b/Tests/ScriptTests/Script Tests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import Script
+
+final class ScriptCoreTests: XCTestCase {
+
+  func testEcho() async throws {
+    try runInScript {
+      var result: String
+      result = try await outputOf {
+        try await echo("1", "2")
+      }
+      // fyi, trailing newline stripped by outputOf
+      XCTAssertEqual("1 2", result, "echo 1 2")
+
+      result = try await outputOf {
+        try await echo("1", "2", separator: ",", terminator: ";")
+      }
+      XCTAssertEqual("1,2;", result, "echo 1,2;")
+    }
+  }
+
+  func testEchoMap() async throws {
+    try runInScript {
+      var result: String
+      result = try await outputOf {
+        // inject newline so map op runs on head then tail
+        try await echo("1", "2", "\n", "3", "4") | map(){"<\($0)>"}
+      }
+      XCTAssertEqual("<1 2 >\n< 3 4>", result, "echo 1 2 \n 3 4 | map{<$0>}")
+    }
+  }
+
+  /// Run test in Script.run() context
+  private func runInScript(
+    _ op: @escaping RunInScriptProxy.Op,
+    caller: StaticString = #function,
+    callerLine: UInt = #line
+  ) throws {
+    let e = expectation(description: "\(caller):\(callerLine)")
+    try RunInScriptProxy(op, e).run() // sync call preferred
+    wait(for: [e], timeout: 2)
+  }
+
+  private struct RunInScriptProxy: Script {
+    typealias Op = () async throws -> Void
+    var op: Op?
+    var e: XCTestExpectation?
+    init(_ op: @escaping Op, _ e: XCTestExpectation) {
+      self.op = op
+      self.e = e
+    }
+    func run() async throws {
+      defer { e?.fulfill() }
+      try await op?()
+    }
+    // Codable
+    init() {}
+    var i = 0
+    private enum CodingKeys: String, CodingKey {
+      case i
+    }
+  }
+}
+


### PR DESCRIPTION
Per the discussion on #24, this variant for #20 is intended as minimal.

For Shwift it has the original fix for #22 and split Line segments.

For Script it has only `splitInput`.  That includes a reducing operation and thus is (properly) not usable as pipe source.  It could be renamed to `splitInputAndReduce` for clarity, but it's the only split API and the parameters and type make its operation pretty clear. 

The reduce operation takes a String rather than an AsyncSequence of String.  It's simpler and doesn't lose much useful functionality (and I couldn't get that working :)